### PR TITLE
bump actions/checkout to v4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: golang:latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get dependencies
       run: go get -v -t -d ./...
     - name: Run tests


### PR DESCRIPTION
This PR bumps the `actions/checkout` from `v3` to `v4`.

_Issue warned on actions tab_
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
