### PR TITLE
remove neotoolkit/faker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1853,8 +1853,7 @@ _These libraries were placed here because none of the other categories seemed to
 - [captcha](https://github.com/steambap/captcha) - Package captcha provides an easy to use, unopinionated API for captcha generation.
 - [common](https://github.com/kubeservice-stack/common) - A library for server framework.
 - [conv](https://github.com/cstockton/go-conv) - Package conv provides fast and intuitive conversions across Go types.
-- [datacounter](https://github.com/miolini/datacounter) - Go counters for readers/writer/http.ResponseWriter.
-- [faker](https://github.com/neotoolkit/faker) - Fake data generator.
+- [datacounter](https://github.com/miolini/datacounter) - Go counters for readers/writer/http.ResponseWriter. 
 - [faker](https://github.com/pioz/faker) - Random fake data and struct generator for Go.
 - [ffmt](https://github.com/go-ffmt/ffmt) - Beautify data display for Humans.
 - [gatus](https://github.com/TwinProduction/gatus) - Automated service health dashboard.


### PR DESCRIPTION
Remove: https://github.com/neotoolkit/faker

It's now archived.
